### PR TITLE
Used ADMIN_RESOURCE constant for authorization

### DIFF
--- a/Controller/Adminhtml/AbstractService.php
+++ b/Controller/Adminhtml/AbstractService.php
@@ -31,6 +31,11 @@ use Smile\RetailerService\Api\Data\ServiceInterfaceFactory;
 abstract class AbstractService extends Action
 {
     /**
+     * Authorization level of a basic admin session
+     */
+    const ADMIN_RESOURCE = 'Smile_RetailerService::retailer_services';
+
+    /**
      * @var \Magento\Framework\View\Result\PageFactory|null
      */
     protected $resultPageFactory = null;
@@ -93,17 +98,5 @@ abstract class AbstractService extends Action
             ->addBreadcrumb(__('Sellers'), __('Retailers'), __('Services'));
 
         return $resultPage;
-    }
-
-    /**
-     * Check if allowed to manage service
-     *
-     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
-     *
-     * @return bool
-     */
-    protected function _isAllowed()
-    {
-        return $this->_authorization->isAllowed('Smile_RetailerService::retailer_services');
     }
 }


### PR DESCRIPTION
Hi!

Removed override for _isAllowed method, because Magento recommends to use constant ADMIN_RESOURCE. In base class  Magento\Backend\App\Action it looks as:
` protected function _isAllowed()
    {
        return $this->_authorization->isAllowed(static::ADMIN_RESOURCE);
    }`
 